### PR TITLE
fixed issue where overwriting output folder was failing

### DIFF
--- a/simpletransformers/classification/classification_model.py
+++ b/simpletransformers/classification/classification_model.py
@@ -529,6 +529,9 @@ class ClassificationModel:
 
         if args:
             self.args.update_from_dict(args)
+            
+        if kwargs:
+            self.args.update_from_dict(kwargs)
 
         if self.args.silent:
             show_running_loss = False


### PR DESCRIPTION
Issue: Keyword arguments not being updated

Code to reproduce:
```
from simpletransformers.classification import ClassificationModel, ClassificationArgs
import pandas as pd
import os

model_args = ClassificationArgs(num_train_epochs=1)

# Create a ClassificationModel
model = ClassificationModel(
    'bert',
    'bert-base-cased',
    num_labels=7,
    use_cuda = False,
    args=model_args
)

# Preparing train data
train_data = [
    ["Aragorn was the heir of Isildur", 1],
    ["Frodo was the heir of Isildur", 0],
    ["Pippin is stronger than Merry", 2],
]
train_df = pd.DataFrame(train_data)
train_df.columns = ["text", "labels"]

# create a non-empty dir
os.mkdir('outputs/')
with open('outputs/foo.txt', 'w') as f:
    f.write('Hello, World!')

model.train_model(train_df, output_dir = 'outputs/', overwrite_output_dir = True)
```

Exception:
```
ValueError: Output directory (outputs/) already exists and is not empty. Set overwrite_output_dir: True to automatically overwrite.
```

Expected behavior: Should overwrite existing files

Fix: Update ```self.args``` with ```kwargs``` if it is passed